### PR TITLE
GG-49407 Remove jitpack references from GridGain 9 examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,9 +93,6 @@ repositories {
         name = "gridgain"
         url = uri("https://maven.gridgain.com/nexus/content/repositories/external")
     }
-    maven {
-        url = uri('https://jitpack.io')
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Scalecube is now published to maven.gridgain.com, so the `jitpack.io` repository is removed from the examples build. The `maven.gridgain.com/.../external` repository (already declared right above it) serves everything the examples need.

Jira: https://ggsystems.atlassian.net/browse/GG-49407

🤖 Generated with [Claude Code](https://claude.com/claude-code)